### PR TITLE
Set `Vary` header to `X-Inertia`

### DIFF
--- a/lib/inertia/controller.ex
+++ b/lib/inertia/controller.ex
@@ -34,7 +34,7 @@ defmodule Inertia.Controller do
     conn
     |> put_status(200)
     |> put_resp_header("x-inertia", "true")
-    |> put_resp_header("vary", "Accept")
+    |> put_resp_header("vary", "X-Inertia")
     |> json(inertia_assigns(conn))
   end
 


### PR DESCRIPTION
Following Inertia author on this one: https://github.com/inertiajs/inertia-laravel/pull/404, since he updated the `Vary` header to be `X-Inertia` instead of `Accept`.