### PR TITLE
Fix CSR fallback crash when SSR returns non-string error

### DIFF
--- a/lib/inertia/controller.ex
+++ b/lib/inertia/controller.ex
@@ -839,6 +839,8 @@ defmodule Inertia.Controller do
           send_ssr_response(conn, head, body)
 
         {:error, message} ->
+          message = if is_binary(message), do: message, else: inspect(message)
+
           if raise_on_ssr_failure?() do
             raise RenderError, message: message
           else

--- a/test/inertia_test.exs
+++ b/test/inertia_test.exs
@@ -163,6 +163,26 @@ defmodule InertiaTest do
     assert body =~ ~s("component":"Home") |> html_escape()
   end
 
+  @tag :capture_log
+  test "falls back to CSR if SSR worker crashes with non-string error", %{conn: conn} do
+    path =
+      __ENV__.file
+      |> Path.dirname()
+      |> Path.join("js")
+
+    start_supervised({Inertia.SSR, path: path, module: "ssr-crash"})
+
+    Application.put_env(:inertia, :ssr, true)
+    Application.put_env(:inertia, :raise_on_ssr_failure, false)
+
+    conn =
+      conn
+      |> get(~p"/")
+
+    body = html_response(conn, 200)
+    assert body =~ ~s("component":"Home") |> html_escape()
+  end
+
   test "raises on SSR failure when failure mode is set to raise", %{conn: conn} do
     path =
       __ENV__.file

--- a/test/js/ssr-crash.js
+++ b/test/js/ssr-crash.js
@@ -1,0 +1,6 @@
+// A dummy module to simulate a Node.js worker crash (e.g. V8 OOM)
+module.exports = {
+  render: (_page) => {
+    process.exit(134);
+  },
+};


### PR DESCRIPTION
## Problem

When a Node.js SSR worker crashes (e.g. V8 OOM with exit code 134), the `nodejs` library returns `{:error, {:node_js_worker_exit, <tuple>}}` instead of `{:error, "string message"}`.

In `send_response/1`, this matches `{:error, message}` where `message` is a tuple. The Logger call on line 845 does `"...\n\n#{message}"`, which calls `String.Chars.to_string/1` on the tuple and raises `Protocol.UndefinedError`. The CSR fallback on the next line never executes, and the user gets a 500.

The `raise_on_ssr_failure` path has the same issue: `RenderError` expects `message` to be a string.

## Fix

Coerce `message` with `inspect/1` when it's not a binary, before logging or raising:

```elixir
{:error, message} ->
  message = if is_binary(message), do: message, else: inspect(message)
```

## Test

Added `test/js/ssr-crash.js` that calls `process.exit(134)` to simulate a worker crash. The test asserts the request still returns 200 (CSR fallback) instead of crashing.