### PR TITLE
Support graceful failure for deferred props (rescuedProps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add a `:csp_nonce_assign_key` config option. When set, the library reads a Content-Security-Policy nonce from the given connection assign and applies it to the `<script>` tag used to bootstrap the page data.
 - The `:match_on` option on `inertia_merge/2`, `inertia_prepend/2`, and `inertia_deep_merge/2` now accepts a list of keys (in addition to a single key) for matching on multiple fields, producing one `matchPropsOn` entry per key.
+- Add an `on_error: :ignore` option to `inertia_defer/2,3` for graceful failure of deferred props. When a rescued deferred prop's resolver fails during a partial reload, the prop is omitted, its path is reported in the `rescuedProps` page metadata, and the failure is logged and emitted as a `[:inertia, :deferred_prop, :rescue]` telemetry event ([#75](https://github.com/inertiajs/inertia-phoenix/issues/75)).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,27 @@ conn
 
 If no group names are specified, then the client-side will issue a single async request to fetch all the deferred props. If there are multiple group names, then the client-side will issue one async request per group instead. This is useful if you have some very expensive data that you'd prefer fetch in parallel alongside other expensive data.
 
+### Graceful failure with `on_error: :ignore`
+
+By default, if a deferred prop's resolver raises while the client is fetching its group, the error propagates and the partial reload fails. Pass `on_error: :ignore` to degrade gracefully instead: the error is contained, the prop is omitted from the response, and its path is reported in the `rescuedProps` page metadata so the client can render a fallback.
+
+```elixir
+conn
+|> assign_prop(:stats, inertia_defer(fn -> expensive_stats() end, on_error: :ignore))
+
+# With a custom group
+|> assign_prop(:stats, inertia_defer(fn -> expensive_stats() end, "dashboard", on_error: :ignore))
+```
+
+Rescued failures are logged and emit a `[:inertia, :deferred_prop, :rescue]` telemetry event with the following metadata, so you can report them to your error tracker:
+
+```elixir
+:telemetry.attach("inertia-rescue", [:inertia, :deferred_prop, :rescue], fn _event, _measurements, metadata, _config ->
+  # metadata: %{prop: "stats", kind: :error | :throw | :exit, reason: term(), stacktrace: [...]}
+  MyApp.ErrorReporter.report(metadata)
+end, nil)
+```
+
 ## Merge props
 
 **Requires Inertia v2.x or later on the client-side**.

--- a/lib/inertia/controller.ex
+++ b/lib/inertia/controller.ex
@@ -42,7 +42,8 @@ defmodule Inertia.Controller do
               match_props_on: [],
               deferred_props: %{},
               once_props: %{},
-              scroll_props: %{}
+              scroll_props: %{},
+              rescued_props: []
   end
 
   defmodule ResolveContext do
@@ -57,7 +58,7 @@ defmodule Inertia.Controller do
   @opaque merge() :: {:merge, any()} | {:merge, any(), String.t()}
   @opaque prepend() :: {:prepend, any()} | {:prepend, any(), String.t()}
   @opaque deep_merge() :: {:deep_merge, any()} | {:deep_merge, any(), String.t()}
-  @opaque defer() :: {:defer, {fun(), String.t()}}
+  @opaque defer() :: {:defer, {fun(), String.t()}} | {:defer, {fun(), String.t(), atom()}}
   @opaque once() :: Once.t()
   @opaque scroll() :: Scroll.t()
   @opaque shared() :: {:shared, any()}
@@ -159,6 +160,30 @@ defmodule Inertia.Controller do
 
   @doc """
   Marks that a prop should fetched immediately after the page is loaded on the client-side.
+
+  ## Options
+
+  - `:on_error` - Controls what happens when the prop's resolver fails while the
+    client is fetching its deferred group. Defaults to letting the error
+    propagate (failing the partial reload). Pass `:ignore` to degrade
+    gracefully: the error is contained, the prop is omitted from the response,
+    and its path is reported in the `rescuedProps` page metadata so the client
+    can render a fallback. Rescued failures emit a
+    `[:inertia, :deferred_prop, :rescue]` telemetry event and are logged.
+
+  ## Examples
+
+      # Default group
+      assign_prop(conn, :stats, inertia_defer(fn -> expensive_stats() end))
+
+      # Custom group
+      assign_prop(conn, :stats, inertia_defer(fn -> expensive_stats() end, "dashboard"))
+
+      # Degrade gracefully if the resolver fails
+      assign_prop(conn, :stats, inertia_defer(fn -> expensive_stats() end, on_error: :ignore))
+
+      # Custom group + graceful failure
+      assign_prop(conn, :stats, inertia_defer(fn -> expensive_stats() end, "dashboard", on_error: :ignore))
   """
   @doc since: "1.0.0"
   @spec inertia_defer(fun :: fun()) :: defer()
@@ -170,12 +195,55 @@ defmodule Inertia.Controller do
 
   @doc since: "1.0.0"
   @spec inertia_defer(fun :: fun(), group :: String.t()) :: defer()
+  @spec inertia_defer(fun :: fun(), opts :: keyword()) :: defer()
   def inertia_defer(fun, group) when is_function(fun) and is_binary(group) do
     {:defer, {fun, group}}
   end
 
+  def inertia_defer(fun, opts) when is_function(fun) and is_list(opts) do
+    build_defer(fun, "default", opts)
+  end
+
   def inertia_defer(_, _) do
-    raise ArgumentError, message: "inertia_defer/2 only accepts function and group arguments"
+    raise ArgumentError,
+      message: "inertia_defer/2 only accepts function and group (or options) arguments"
+  end
+
+  @doc since: "3.0.0"
+  @spec inertia_defer(fun :: fun(), group :: String.t(), opts :: keyword()) :: defer()
+  def inertia_defer(fun, group, opts)
+      when is_function(fun) and is_binary(group) and is_list(opts) do
+    build_defer(fun, group, opts)
+  end
+
+  def inertia_defer(_, _, _) do
+    raise ArgumentError,
+      message: "inertia_defer/3 only accepts function, group, and options arguments"
+  end
+
+  defp build_defer(fun, group, opts) do
+    case Keyword.validate(opts, [:on_error]) do
+      {:ok, opts} ->
+        apply_defer_opts(fun, group, opts)
+
+      {:error, invalid} ->
+        raise ArgumentError,
+          message: "inertia_defer received invalid options: #{inspect(invalid)}"
+    end
+  end
+
+  defp apply_defer_opts(fun, group, opts) do
+    case Keyword.get(opts, :on_error) do
+      nil ->
+        {:defer, {fun, group}}
+
+      :ignore ->
+        {:defer, {fun, group, :ignore}}
+
+      other ->
+        raise ArgumentError,
+          message: "inertia_defer :on_error only accepts :ignore, got: #{inspect(other)}"
+    end
   end
 
   @doc """
@@ -646,6 +714,7 @@ defmodule Inertia.Controller do
       deferred_props: meta.deferred_props,
       once_props: meta.once_props,
       scroll_props: meta.scroll_props,
+      rescued_props: meta.rescued_props,
       shared_props: shared_prop_keys,
       is_partial: is_partial
     })
@@ -827,15 +896,82 @@ defmodule Inertia.Controller do
 
       # Step 6: Initial-response exclusion for optional props
       if ctx.is_partial or not optional?(value) do
-        {value, meta} =
-          finalize_prop(value, path, meta, ctx, parent_was_resolved, was_resolved)
-
-        output_key = transform_key(key, ctx.opts)
-        {Map.put(props_acc, output_key, value), meta}
+        finalize_and_put(
+          key,
+          value,
+          path,
+          props_acc,
+          meta,
+          ctx,
+          parent_was_resolved,
+          was_resolved
+        )
       else
         {props_acc, meta}
       end
     end
+  end
+
+  # Resolves a rescuable deferred prop within a try/catch. If resolution of the
+  # prop (including its nested values) fails, the prop is omitted, its path is
+  # recorded in rescued_props, and the failure is reported via telemetry +
+  # logging. A nested *rescuable* prop still handles its own failure first (via
+  # its own clause here), so it is reported under its own path; only otherwise
+  # unhandled failures bubble up to this ancestor.
+  defp finalize_and_put(
+         key,
+         {:optional, fun, :rescue},
+         path,
+         props_acc,
+         meta,
+         ctx,
+         parent_was_resolved,
+         was_resolved
+       ) do
+    {value, resolved_meta} =
+      finalize_prop({:optional, fun}, path, meta, ctx, parent_was_resolved, was_resolved)
+
+    put_resolved(props_acc, key, value, resolved_meta, ctx)
+  rescue
+    exception ->
+      report_rescued_prop(path, :error, exception, __STACKTRACE__)
+      {props_acc, %{meta | rescued_props: [path | meta.rescued_props]}}
+  catch
+    kind, reason ->
+      report_rescued_prop(path, kind, reason, __STACKTRACE__)
+      {props_acc, %{meta | rescued_props: [path | meta.rescued_props]}}
+  end
+
+  defp finalize_and_put(
+         key,
+         value,
+         path,
+         props_acc,
+         meta,
+         ctx,
+         parent_was_resolved,
+         was_resolved
+       ) do
+    {value, meta} = finalize_prop(value, path, meta, ctx, parent_was_resolved, was_resolved)
+    put_resolved(props_acc, key, value, meta, ctx)
+  end
+
+  defp put_resolved(props_acc, key, value, meta, ctx) do
+    output_key = transform_key(key, ctx.opts)
+    {Map.put(props_acc, output_key, value), meta}
+  end
+
+  defp report_rescued_prop(path, kind, reason, stacktrace) do
+    :telemetry.execute(
+      [:inertia, :deferred_prop, :rescue],
+      %{},
+      %{prop: path, kind: kind, reason: reason, stacktrace: stacktrace}
+    )
+
+    Logger.error(
+      "Inertia rescued deferred prop #{inspect(path)}:\n" <>
+        Exception.format(kind, reason, stacktrace)
+    )
   end
 
   defp finalize_prop(value, path, meta, ctx, parent_was_resolved, was_resolved) do
@@ -1090,13 +1226,20 @@ defmodule Inertia.Controller do
   end
 
   defp collect_metadata({:defer, {fun, group}}, path, _ctx, meta) do
-    deferred = meta.deferred_props
-    group_keys = Map.get(deferred, group, [])
-    meta = %{meta | deferred_props: Map.put(deferred, group, [path | group_keys])}
-    {{:optional, fun}, meta}
+    {{:optional, fun}, record_deferred(meta, group, path)}
+  end
+
+  defp collect_metadata({:defer, {fun, group, :ignore}}, path, _ctx, meta) do
+    {{:optional, fun, :rescue}, record_deferred(meta, group, path)}
   end
 
   defp collect_metadata(value, _path, _ctx, meta), do: {value, meta}
+
+  defp record_deferred(meta, group, path) do
+    deferred = meta.deferred_props
+    group_keys = Map.get(deferred, group, [])
+    %{meta | deferred_props: Map.put(deferred, group, [path | group_keys])}
+  end
 
   # Builds the "path.field" match entries for the matchPropsOn page metadata.
   # The client splits each entry on the final "." to derive the prop path and
@@ -1109,6 +1252,7 @@ defmodule Inertia.Controller do
   defp match_prop_entries(path, match_key), do: ["#{path}.#{match_key}"]
 
   defp optional?({:optional, _}), do: true
+  defp optional?({:optional, _, :rescue}), do: true
   defp optional?(_), do: false
 
   defp unwrap_tags({:optional, v}), do: v
@@ -1266,6 +1410,7 @@ defmodule Inertia.Controller do
     |> maybe_put_deferred_props(conn)
     |> maybe_put_once_props(conn)
     |> maybe_put_scroll_props(conn)
+    |> maybe_put_rescued_props(conn)
     |> maybe_put_shared_props(conn)
     |> maybe_put_preserve_fragment(conn)
   end
@@ -1354,6 +1499,16 @@ defmodule Inertia.Controller do
       assigns
     else
       Map.put(assigns, :scrollProps, scroll_props)
+    end
+  end
+
+  defp maybe_put_rescued_props(assigns, conn) do
+    rescued_props = conn.private.inertia_page.rescued_props
+
+    if Enum.empty?(rescued_props) do
+      assigns
+    else
+      Map.put(assigns, :rescuedProps, rescued_props)
     end
   end
 

--- a/lib/inertia/ssr/adapter.ex
+++ b/lib/inertia/ssr/adapter.ex
@@ -36,6 +36,7 @@ defmodule Inertia.SSR.Adapter do
           optional(:deferredProps) => map(),
           optional(:onceProps) => map(),
           optional(:scrollProps) => map(),
+          optional(:rescuedProps) => list(String.t()),
           optional(:sharedProps) => list(String.t()),
           optional(:preserveFragment) => boolean()
         }

--- a/lib/inertia/testing.ex
+++ b/lib/inertia/testing.ex
@@ -192,4 +192,17 @@ defmodule Inertia.Testing do
     page = conn.private[:inertia_page] || %{}
     page[:once_props] || %{}
   end
+
+  @doc """
+  Fetches the rescued prop paths for the current request.
+
+  Returns the list of deferred prop paths whose resolution failed and were
+  rescued (via `inertia_defer(..., on_error: :ignore)`).
+  """
+  @doc since: "3.0.0"
+  @spec inertia_rescued_props(Plug.Conn.t()) :: list(String.t())
+  def inertia_rescued_props(conn) do
+    page = conn.private[:inertia_page] || %{}
+    page[:rescued_props] || []
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule Inertia.MixProject do
       {:phoenix_live_view, "~> 1.0"},
       {:plug, ">= 1.5.0 and < 2.0.0"},
       {:jason, "~> 1.2"},
+      {:telemetry, "~> 1.0"},
       {:bandit, "~> 1.2", only: :test},
       {:phoenix_view, "~> 2.0", only: :test},
       {:plug_cowboy, "~> 2.1", only: :test},

--- a/test/inertia/controller_test.exs
+++ b/test/inertia/controller_test.exs
@@ -1,7 +1,8 @@
 defmodule Inertia.ControllerTest do
   use ExUnit.Case, async: true
 
-  import Inertia.Controller, only: [inertia_optional: 1, inertia_defer: 1, inertia_defer: 2]
+  import Inertia.Controller,
+    only: [inertia_optional: 1, inertia_defer: 1, inertia_defer: 2, inertia_defer: 3]
 
   describe "inertia_optional/1" do
     test "tags a value as optional" do
@@ -46,6 +47,65 @@ defmodule Inertia.ControllerTest do
 
       assert_raise(ArgumentError, fn ->
         inertia_defer(fun, 3)
+      end)
+    end
+
+    test "accepts on_error: :ignore as options" do
+      fun = fn -> 1 end
+      assert inertia_defer(fun, on_error: :ignore) == {:defer, {fun, "default", :ignore}}
+    end
+
+    test "treats an empty keyword list as the default group" do
+      fun = fn -> 1 end
+      assert inertia_defer(fun, []) == {:defer, {fun, "default"}}
+    end
+
+    test "raises when given a non-keyword list instead of silently defaulting" do
+      fun = fn -> 1 end
+
+      assert_raise(ArgumentError, fn ->
+        inertia_defer(fun, ["dashboard", "sidebar"])
+      end)
+    end
+
+    test "raises on an unknown option" do
+      fun = fn -> 1 end
+
+      assert_raise(ArgumentError, fn ->
+        inertia_defer(fun, on_errors: :ignore)
+      end)
+    end
+
+    test "raises on an invalid on_error value" do
+      fun = fn -> 1 end
+
+      assert_raise(ArgumentError, fn ->
+        inertia_defer(fun, on_error: :explode)
+      end)
+    end
+  end
+
+  describe "inertia_defer/3" do
+    test "tags as deferred with given group and options" do
+      fun = fn -> 1 end
+
+      assert inertia_defer(fun, "dashboard", on_error: :ignore) ==
+               {:defer, {fun, "dashboard", :ignore}}
+    end
+
+    test "raises an argument error if group is not a string" do
+      fun = fn -> 1 end
+
+      assert_raise(ArgumentError, fn ->
+        inertia_defer(fun, 3, on_error: :ignore)
+      end)
+    end
+
+    test "raises on an unknown option" do
+      fun = fn -> 1 end
+
+      assert_raise(ArgumentError, fn ->
+        inertia_defer(fun, "dashboard", bogus: true)
       end)
     end
   end

--- a/test/inertia_test.exs
+++ b/test/inertia_test.exs
@@ -3,6 +3,7 @@ defmodule InertiaTest do
   use Phoenix.Component
 
   import Plug.Conn
+  import ExUnit.CaptureLog
 
   @current_version "db137d38dc4b6ee57d5eedcf0182de8a"
 
@@ -830,6 +831,188 @@ defmodule InertiaTest do
 
     # The deferred props list should not be returned on partial requests
     refute "deferredProps" in Map.keys(body)
+  end
+
+  # Rescued deferred props (on_error: :ignore)
+
+  test "rescuable deferred props behave like normal deferred props on initial load", %{conn: conn} do
+    conn = get(conn, ~p"/rescued_deferred_props")
+
+    body = html_response(conn, 200)
+    props = extract_page_data_from_html(body)
+
+    # Deferred — excluded from props, listed in deferredProps by group
+    refute Map.has_key?(props["props"], "ok")
+    refute Map.has_key?(props["props"], "boom")
+
+    assert props["deferredProps"]["default"]
+           |> MapSet.new()
+           |> MapSet.equal?(MapSet.new(["ok", "boom", "auth.permissions"]))
+
+    assert props["deferredProps"]["other"] == ["thrown"]
+
+    # Nothing has been resolved yet, so nothing is rescued
+    refute Map.has_key?(props, "rescuedProps")
+  end
+
+  test "rescues a failing deferred prop on partial reload, omitting it and reporting the path",
+       %{conn: conn} do
+    {conn, log} =
+      with_log(fn ->
+        conn
+        |> put_req_header("x-inertia", "true")
+        |> put_req_header("x-inertia-version", @current_version)
+        |> put_req_header("x-inertia-partial-component", "Home")
+        |> put_req_header("x-inertia-partial-data", "ok,boom")
+        |> get(~p"/rescued_deferred_props")
+      end)
+
+    body = json_response(conn, 200)
+
+    # The healthy prop resolves; the failing one is omitted
+    assert body["props"]["ok"] == "ok"
+    refute Map.has_key?(body["props"], "boom")
+
+    # The failing prop's path is reported in rescuedProps
+    assert body["rescuedProps"] == ["boom"]
+
+    # The failure is logged, not silently dropped
+    assert log =~ "Inertia rescued deferred prop \"boom\""
+    assert log =~ "kaboom"
+  end
+
+  test "rescues thrown values (not just raised exceptions)", %{conn: conn} do
+    {conn, _log} =
+      with_log(fn ->
+        conn
+        |> put_req_header("x-inertia", "true")
+        |> put_req_header("x-inertia-version", @current_version)
+        |> put_req_header("x-inertia-partial-component", "Home")
+        |> put_req_header("x-inertia-partial-data", "thrown")
+        |> get(~p"/rescued_deferred_props")
+      end)
+
+    body = json_response(conn, 200)
+
+    refute Map.has_key?(body["props"], "thrown")
+    assert body["rescuedProps"] == ["thrown"]
+  end
+
+  test "emits a telemetry event when a deferred prop is rescued", %{conn: conn} do
+    ref = make_ref()
+    parent = self()
+    handler_id = {:rescue_test, ref}
+
+    :telemetry.attach(
+      handler_id,
+      [:inertia, :deferred_prop, :rescue],
+      fn event, measurements, metadata, _config ->
+        send(parent, {ref, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    with_log(fn ->
+      conn
+      |> put_req_header("x-inertia", "true")
+      |> put_req_header("x-inertia-version", @current_version)
+      |> put_req_header("x-inertia-partial-component", "Home")
+      |> put_req_header("x-inertia-partial-data", "boom")
+      |> get(~p"/rescued_deferred_props")
+    end)
+
+    assert_received {^ref, [:inertia, :deferred_prop, :rescue], %{}, metadata}
+    assert metadata.prop == "boom"
+    assert metadata.kind == :error
+    assert %RuntimeError{message: "kaboom"} = metadata.reason
+    assert is_list(metadata.stacktrace)
+  end
+
+  test "a deferred prop without on_error: :ignore still raises", %{conn: conn} do
+    assert_raise RuntimeError, "kaboom", fn ->
+      conn
+      |> put_req_header("x-inertia", "true")
+      |> put_req_header("x-inertia-version", @current_version)
+      |> put_req_header("x-inertia-partial-component", "Home")
+      |> put_req_header("x-inertia-partial-data", "boom")
+      |> get(~p"/unrescued_deferred_props")
+    end
+  end
+
+  test "rescues a failing nested deferred prop using its dot-path", %{conn: conn} do
+    {conn, _log} =
+      with_log(fn ->
+        conn
+        |> put_req_header("x-inertia", "true")
+        |> put_req_header("x-inertia-version", @current_version)
+        |> put_req_header("x-inertia-partial-component", "Home")
+        |> put_req_header("x-inertia-partial-data", "auth.permissions")
+        |> get(~p"/rescued_deferred_props")
+      end)
+
+    body = json_response(conn, 200)
+
+    refute Map.has_key?(body["props"]["auth"], "permissions")
+    assert body["rescuedProps"] == ["auth.permissions"]
+  end
+
+  test "a failing nested rescuable child is reported under its own path and healthy siblings survive",
+       %{conn: conn} do
+    {conn, _log} =
+      with_log(fn ->
+        conn
+        |> put_req_header("x-inertia", "true")
+        |> put_req_header("x-inertia-version", @current_version)
+        |> put_req_header("x-inertia-partial-component", "Home")
+        |> put_req_header("x-inertia-partial-data", "stats")
+        |> get(~p"/nested_rescue_deferred_props")
+      end)
+
+    body = json_response(conn, 200)
+
+    # The parent resolver succeeded, so its healthy data survives...
+    assert body["props"]["stats"]["healthy"] == "ok"
+    refute Map.has_key?(body["props"]["stats"], "broken")
+
+    # ...and only the failing child is reported, under its own dot-path
+    # (not the rescuable parent's path).
+    assert body["rescuedProps"] == ["stats.broken"]
+  end
+
+  test "an unrescuable failure nested inside a rescuable prop degrades gracefully under the parent",
+       %{conn: conn} do
+    {conn, _log} =
+      with_log(fn ->
+        conn
+        |> put_req_header("x-inertia", "true")
+        |> put_req_header("x-inertia-version", @current_version)
+        |> put_req_header("x-inertia-partial-component", "Home")
+        |> put_req_header("x-inertia-partial-data", "stats")
+        |> get(~p"/nested_unrescuable_failure_deferred_props")
+      end)
+
+    # The nested lazy value has no rescue of its own, so the whole rescuable
+    # parent is omitted and reported under the parent path (a 200, not a 500).
+    body = json_response(conn, 200)
+
+    refute Map.has_key?(body["props"], "stats")
+    assert body["rescuedProps"] == ["stats"]
+  end
+
+  test "inertia_rescued_props/1 returns the rescued prop paths", %{conn: conn} do
+    {conn, _log} =
+      with_log(fn ->
+        conn
+        |> put_req_header("x-inertia", "true")
+        |> put_req_header("x-inertia-version", @current_version)
+        |> put_req_header("x-inertia-partial-component", "Home")
+        |> put_req_header("x-inertia-partial-data", "ok,boom")
+        |> get(~p"/rescued_deferred_props")
+      end)
+
+    assert Inertia.Testing.inertia_rescued_props(conn) == ["boom"]
   end
 
   test "instructs the client-side to encrypt history", %{conn: conn} do

--- a/test/support/my_app/lib/my_app_web/controllers/page_controller.ex
+++ b/test/support/my_app/lib/my_app_web/controllers/page_controller.ex
@@ -131,6 +131,57 @@ defmodule MyAppWeb.PageController do
     |> render_inertia("Home")
   end
 
+  def rescued_deferred_props(conn, _params) do
+    conn
+    |> assign(:page_title, "Home")
+    |> assign_prop(:ok, inertia_defer(fn -> "ok" end, on_error: :ignore))
+    |> assign_prop(:boom, inertia_defer(fn -> raise "kaboom" end, on_error: :ignore))
+    |> assign_prop(:thrown, inertia_defer(fn -> throw(:nope) end, "other", on_error: :ignore))
+    |> assign_prop(:auth, %{
+      user: "Alice",
+      permissions: inertia_defer(fn -> raise "no perms" end, on_error: :ignore)
+    })
+    |> render_inertia("Home")
+  end
+
+  def nested_rescue_deferred_props(conn, _params) do
+    conn
+    |> assign(:page_title, "Home")
+    |> assign_prop(
+      :stats,
+      inertia_defer(
+        fn ->
+          %{
+            healthy: "ok",
+            broken: inertia_defer(fn -> raise "child boom" end, on_error: :ignore)
+          }
+        end,
+        on_error: :ignore
+      )
+    )
+    |> render_inertia("Home")
+  end
+
+  def nested_unrescuable_failure_deferred_props(conn, _params) do
+    conn
+    |> assign(:page_title, "Home")
+    |> assign_prop(
+      :stats,
+      inertia_defer(
+        fn -> %{healthy: "ok", broken: fn -> raise "lazy boom" end} end,
+        on_error: :ignore
+      )
+    )
+    |> render_inertia("Home")
+  end
+
+  def unrescued_deferred_props(conn, _params) do
+    conn
+    |> assign(:page_title, "Home")
+    |> assign_prop(:boom, inertia_defer(fn -> raise "kaboom" end))
+    |> render_inertia("Home")
+  end
+
   def encrypted_history(conn, _params) do
     conn
     |> assign(:page_title, "Home")

--- a/test/support/my_app/lib/my_app_web/router.ex
+++ b/test/support/my_app/lib/my_app_web/router.ex
@@ -31,6 +31,13 @@ defmodule MyAppWeb.Router do
     get "/merge_props", PageController, :merge_props
     get "/deep_merge_props", PageController, :deep_merge_props
     get "/deferred_props", PageController, :deferred_props
+    get "/rescued_deferred_props", PageController, :rescued_deferred_props
+    get "/nested_rescue_deferred_props", PageController, :nested_rescue_deferred_props
+
+    get "/nested_unrescuable_failure_deferred_props",
+        PageController,
+        :nested_unrescuable_failure_deferred_props
+    get "/unrescued_deferred_props", PageController, :unrescued_deferred_props
     get "/encrypted_history", PageController, :encrypted_history
     get "/cleared_history", PageController, :cleared_history
     get "/preserved_fragment", PageController, :preserved_fragment


### PR DESCRIPTION
Closes #75.

Adds an `on_error: :ignore` option to `inertia_defer/2,3` for graceful failure of deferred props, matching the Laravel reference adapter's `rescue`/`rescuedProps` behavior.

## Behavior

When a rescuable deferred prop's resolver fails while the client is fetching its group, the failure is contained: the prop is omitted from the response and its path is reported in the `rescuedProps` page metadata so the client can render a fallback (instead of failing the whole partial reload).

```elixir
# Degrade gracefully if the resolver fails
assign_prop(conn, :stats, inertia_defer(fn -> expensive_stats() end, on_error: :ignore))

# With a custom group
assign_prop(conn, :stats, inertia_defer(fn -> expensive_stats() end, "dashboard", on_error: :ignore))
```

Default behavior is unchanged — without `on_error: :ignore`, a failing resolver propagates as before.

- The rescue covers **errors, throws, and exits**, preserving the stacktrace.
- A nested *rescuable* prop reports under its own path; an unrescuable nested failure degrades gracefully under the enclosing rescuable prop.
- Options are validated via `Keyword.validate/2` (unknown options and non-keyword lists raise).

## Observability

Rescued failures are logged and emit a telemetry event so they can be forwarded to an error tracker:

```
[:inertia, :deferred_prop, :rescue]
  metadata: %{prop: "stats", kind: :error | :throw | :exit, reason: term(), stacktrace: [...]}
```

## Other changes

- `inertia_rescued_props/1` test helper in `Inertia.Testing`.
- `:rescuedProps` added to the SSR adapter page typespec.
- `:telemetry ~> 1.0` added as an explicit dependency.
- README (deferred-props section) and CHANGELOG updated.

## Tests

209 tests passing; `mix compile --warnings-as-errors`, `mix credo --strict`, and `mix dialyzer` all clean. New coverage: initial-load metadata, partial-reload rescue, throw/exit rescue, telemetry emission, non-rescued-still-raises, nested rescuable child (reported under its own path), unrescuable nested failure (rescued under the parent), and `inertia_defer` option validation.
