### PR TITLE
[Experimental] Add Vite dev-server SSR adapter to the vite/react example

### DIFF
--- a/examples/vite/react/README.md
+++ b/examples/vite/react/README.md
@@ -95,36 +95,59 @@ Vite watcher is running. Omitting it gives a blank page and a
 
 ## Server-side rendering
 
-SSR reuses inertia-phoenix's existing **`Inertia.SSR.NodeJSAdapter`** — no custom
-adapter is needed, because Vite can emit exactly the kind of module the Node pool
-expects:
+This example uses **two different SSR runtimes**, selected by environment, both
+plugged in through inertia-phoenix's `Inertia.SSR.Adapter` behaviour (added in
+[#44](https://github.com/inertiajs/inertia-phoenix/pull/44)):
 
-- **[`assets/js/ssr.jsx`](assets/js/ssr.jsx)** — exports `render(page)` using
-  `ReactDOMServer.renderToString`.
+- **Development** renders through the **running Vite dev server**
+  (`ReactVite.SSR.ViteAdapter`) — no separate SSR build.
+- **Production** renders through the stock **`Inertia.SSR.NodeJSAdapter`** and a
+  pre-built bundle.
+
+Both reuse the same SSR entry, **[`assets/js/ssr.jsx`](assets/js/ssr.jsx)**, which
+exports `render(page)` using `ReactDOMServer.renderToString`.
+
+### Development: the Vite dev-server adapter
+
+In dev, the SSR entry is loaded straight from Vite's module graph — the same
+graph that powers HMR — so editing `ssr.jsx` or any page is reflected on the next
+request with no rebuild and no Phoenix restart.
+
+- **[`assets/vite-plugin-inertia-ssr.mjs`](assets/vite-plugin-inertia-ssr.mjs)** —
+  a dev-only Vite plugin that mounts a `/__inertia_ssr` endpoint on the dev
+  server. It loads the SSR entry via `server.ssrLoadModule(...)`, calls
+  `render(page)`, and returns `{ head, body }` as JSON. `apply: "serve"` makes it
+  a no-op for `vite build`.
+- **[`lib/react_vite/ssr/vite_adapter.ex`](lib/react_vite/ssr/vite_adapter.ex)** —
+  implements `Inertia.SSR.Adapter` by POSTing the page payload to that endpoint
+  (using the built-in `:httpc` client, so no extra dep). Its `children/1` is
+  empty — the dev server is already running as a Phoenix watcher.
+- **[`config/dev.exs`](config/dev.exs)** — sets
+  `config :react_vite, :ssr_adapter, ReactVite.SSR.ViteAdapter` and has **no
+  `ssr` watcher** (the old `vite build --ssr --watch` is gone). It also sets
+  `config :inertia, raise_on_ssr_failure: false`, so a request that beats the dev
+  server to startup falls back to CSR instead of raising.
+
+### Production: the Node.js bundle adapter
+
+In prod there is no dev server, so SSR uses the default Node pool and a
+self-contained bundle:
+
 - **[`vite.config.mjs`](assets/vite.config.mjs)** — the `isSsrBuild` branch builds
   `js/ssr.jsx` into a single **self-contained CommonJS** module at
   `priv/ssr/ssr.cjs` (`ssr.noExternal: true` bundles `react`/`@inertiajs/react`
-  in, so the file needs no `node_modules` at runtime).
-- **[`lib/react_vite/application.ex`](lib/react_vite/application.ex)** — starts
-  `{Inertia.SSR, path: ".../priv/ssr", module: "ssr.cjs"}`.
-- **[`config/dev.exs`](config/dev.exs)** — an `ssr` watcher runs
-  `vite build --ssr --watch`. Because the bundle is CommonJS, the Node pool
-  re-`require`s it on every render in development (`NODE_ENV !== "production"`),
-  so SSR picks up your edits without restarting Phoenix.
+  in, so the file needs no `node_modules` at runtime). `mix assets.build` runs
+  this `--ssr` step.
+- **[`lib/react_vite/application.ex`](lib/react_vite/application.ex)** — when
+  `:ssr_adapter` is unset (prod/test) it starts
+  `{Inertia.SSR, path: ".../priv/ssr", module: "ssr.cjs"}`; when set (dev) it
+  starts `{Inertia.SSR, ssr_adapter: ...}`.
 - **`config :inertia, ssr: true`** — `config/test.exs` turns it back off so the
-  test suite doesn't need the Node pool.
+  test suite doesn't need either runtime.
 
-Why CommonJS and not ESM? The Node pool busts its `require` cache between renders
-in development but **caches** dynamic `import()`s, so a CJS bundle is what gives
-live-reloading SSR. (The companion `.cjs` extension keeps Node happy even though
-`package.json` sets `"type": "module"`.)
-
-> **On a dedicated `Inertia.SSR.ViteAdapter`:** the pluggable adapter behaviour
-> added in [#44](https://github.com/inertiajs/inertia-phoenix/pull/44) makes the
-> SSR runtime swappable, but this example shows that React + Vite SSR already
-> works through the stock `NodeJSAdapter`. A purpose-built Vite adapter (e.g. one
-> that renders through Vite's dev-server `ssrLoadModule`, dropping the separate
-> `--ssr --watch` build in development) is a natural next step, not a requirement.
+Why CommonJS and not ESM for the prod bundle? The Node pool busts its `require`
+cache between renders but **caches** dynamic `import()`s. (The companion `.cjs`
+extension keeps Node happy even though `package.json` sets `"type": "module"`.)
 
 ## Notes / gotchas
 

--- a/examples/vite/react/assets/vite-plugin-inertia-ssr.mjs
+++ b/examples/vite/react/assets/vite-plugin-inertia-ssr.mjs
@@ -1,0 +1,46 @@
+// A dev-only Vite plugin that mounts an HTTP endpoint on the Vite dev server
+// for server-side rendering Inertia pages.
+//
+// Instead of running a separate `vite build --ssr --watch` and loading the
+// resulting bundle through a Node pool, this renders by asking the *running*
+// dev server to load the SSR entry through its own module graph
+// (`server.ssrLoadModule`). That transform is HMR-aware, so edits to ssr.jsx
+// or any page are picked up with no rebuild and no Phoenix restart.
+//
+// The Elixir side (ReactVite.SSR.ViteAdapter) POSTs the Inertia page payload
+// here and gets back `{ head, body }`. `apply: "serve"` makes this a no-op for
+// `vite build`, so production builds are unaffected.
+export function inertiaSsr({ entry = "/js/ssr.jsx", path = "/__inertia_ssr" } = {}) {
+  return {
+    name: "inertia-ssr-middleware",
+    apply: "serve",
+    configureServer(server) {
+      server.middlewares.use(path, async (req, res) => {
+        if (req.method !== "POST") {
+          res.statusCode = 405;
+          return res.end();
+        }
+
+        try {
+          const chunks = [];
+          for await (const chunk of req) chunks.push(chunk);
+          const page = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+
+          // Load the SSR entry through Vite's module graph (transformed on
+          // demand, invalidated by HMR), then render the page.
+          const { render } = await server.ssrLoadModule(entry);
+          const { head, body } = await render(page);
+
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ head, body }));
+        } catch (err) {
+          // Rewrite the stack trace to point back at the original source.
+          server.ssrFixStacktrace(err);
+          res.statusCode = 500;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: err.stack || String(err) }));
+        }
+      });
+    },
+  };
+}

--- a/examples/vite/react/assets/vite.config.mjs
+++ b/examples/vite/react/assets/vite.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { phoenixVitePlugin } from "phoenix_vite";
+import { inertiaSsr } from "./vite-plugin-inertia-ssr.mjs";
 
 // Vite runs as a dev server on :5173 alongside Phoenix on :4000. The Phoenix
 // root layout loads assets from this dev server in development (see
@@ -14,15 +15,23 @@ export default defineConfig(({ isSsrBuild }) => ({
   server: {
     port: 5173,
     strictPort: true,
+    // Bind IPv4 explicitly (Vite's default `localhost` can resolve to IPv6-only
+    // `::1`). This matches Phoenix's 127.0.0.1 binding, so the SSR adapter's
+    // server-to-server request reaches the dev server; browsers still reach it
+    // via `localhost` through their IPv4 fallback.
+    host: "127.0.0.1",
     // Generate absolute asset URLs pointing back at the dev server so that
     // code-split page chunks resolve against :5173, not the :4000 page origin.
     origin: "http://localhost:5173",
     // Module scripts are loaded cross-origin from the Phoenix app, so allow it.
     cors: { origin: "http://localhost:4000" },
   },
-  // Bundle dependencies into the SSR output so priv/ssr/ssr.cjs is self-contained
-  // and doesn't need to resolve node_modules at runtime from priv/.
-  ssr: { noExternal: true },
+  // For the SSR *build*, bundle dependencies into the output so priv/ssr/ssr.cjs
+  // is self-contained and needs no node_modules at runtime. In dev, the Vite
+  // adapter renders via the dev server's module runner, which must externalize
+  // CommonJS deps like react (bundling them there breaks with "module is not
+  // defined"), so leave noExternal off when serving.
+  ssr: isSsrBuild ? { noExternal: true } : {},
   build: isSsrBuild
     ? {
         // A single self-contained CommonJS module the Inertia.SSR Node pool loads.
@@ -51,6 +60,9 @@ export default defineConfig(({ isSsrBuild }) => ({
   plugins: [
     react(),
     tailwindcss(),
+    // Mounts the /__inertia_ssr endpoint on the dev server so SSR can render
+    // through ssrLoadModule (no --ssr build). Dev only; a no-op for `vite build`.
+    inertiaSsr(),
     // Keeps phoenix_live_reload in charge of .ex/.heex changes instead of
     // triggering a full Vite page reload.
     phoenixVitePlugin({ pattern: /\.(ex|heex)$/ }),

--- a/examples/vite/react/config/dev.exs
+++ b/examples/vite/react/config/dev.exs
@@ -18,13 +18,22 @@ config :react_vite, ReactViteWeb.Endpoint,
   # (used by the asset tags in root.html.heex) points at it instead of Phoenix.
   static_url: [host: "localhost", port: 5173],
   # Run the Vite dev server alongside Phoenix. PhoenixVite.Npm.run/2 shells out
-  # to `npm exec -- vite ...` (the `:vite` profile in config/config.exs). The
-  # `ssr` watcher rebuilds priv/ssr/ssr.cjs on change; because it's CommonJS the
-  # Inertia.SSR Node pool reloads it without a restart in development.
+  # to `npm exec -- vite ...` (the `:vite` profile in config/config.exs). There
+  # is no `ssr` watcher: SSR renders through this same dev server via the Vite
+  # adapter below (see config :react_vite, :ssr_adapter), so no separate
+  # `vite build --ssr` is needed in development.
   watchers: [
-    vite: {PhoenixVite.Npm, :run, [:vite, ~w(dev)]},
-    ssr: {PhoenixVite.Npm, :run, [:vite, ~w(build --ssr js/ssr.jsx --watch)]}
+    vite: {PhoenixVite.Npm, :run, [:vite, ~w(dev)]}
   ]
+
+# Render SSR through the running Vite dev server instead of the pre-built
+# Node.js bundle. ReactVite.Application reads this to pick the SSR adapter; the
+# dev server exposes the render endpoint via assets/vite-plugin-inertia-ssr.mjs.
+config :react_vite, :ssr_adapter, ReactVite.SSR.ViteAdapter
+
+# Fall back to client-side rendering (instead of raising) if an SSR request
+# can't reach the Vite dev server — e.g. during the brief window while it boots.
+config :inertia, raise_on_ssr_failure: false
 
 # ## SSL Support
 #

--- a/examples/vite/react/lib/react_vite/application.ex
+++ b/examples/vite/react/lib/react_vite/application.ex
@@ -11,11 +11,7 @@ defmodule ReactVite.Application do
       ReactViteWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:react_vite, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: ReactVite.PubSub},
-      # Start the SSR Node.js pool. It loads the self-contained CommonJS bundle
-      # built by `vite build --ssr` (priv/ssr/ssr.cjs) and calls its `render`
-      # export to pre-render Inertia pages on the server.
-      {Inertia.SSR,
-       path: Path.join([Application.app_dir(:react_vite), "priv", "ssr"]), module: "ssr.cjs"},
+      ssr_spec(),
       # Start to serve requests, typically the last entry
       ReactViteWeb.Endpoint
     ]
@@ -32,5 +28,20 @@ defmodule ReactVite.Application do
   def config_change(changed, _new, removed) do
     ReactViteWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  # Selects the SSR runtime. In development (config/dev.exs sets `:ssr_adapter`)
+  # we render through the running Vite dev server, so no `--ssr` build or Node
+  # pool is needed; otherwise (production/test) we load the pre-built CommonJS
+  # bundle (priv/ssr/ssr.cjs) via the default Node.js pool.
+  defp ssr_spec do
+    case Application.get_env(:react_vite, :ssr_adapter) do
+      nil ->
+        {Inertia.SSR,
+         path: Path.join([Application.app_dir(:react_vite), "priv", "ssr"]), module: "ssr.cjs"}
+
+      adapter ->
+        {Inertia.SSR, ssr_adapter: adapter}
+    end
   end
 end

--- a/examples/vite/react/lib/react_vite/ssr/vite_adapter.ex
+++ b/examples/vite/react/lib/react_vite/ssr/vite_adapter.ex
@@ -1,0 +1,78 @@
+defmodule ReactVite.SSR.ViteAdapter do
+  @moduledoc """
+  A development SSR adapter that renders Inertia pages through a running Vite
+  dev server instead of a pre-built bundle.
+
+  The default `Inertia.SSR.NodeJSAdapter` loads a self-contained `ssr.cjs`
+  built by `vite build --ssr` and re-`require`s it per render. This adapter
+  skips that second build entirely: it POSTs the page payload to an endpoint
+  mounted on the Vite dev server (see `assets/vite-plugin-inertia-ssr.mjs`),
+  which renders through Vite's HMR-aware `ssrLoadModule`. Edits to the SSR
+  entry or any page are reflected on the next request — no rebuild, no restart.
+
+  This is a development-only path: in production there is no dev server, so the
+  app falls back to the Node.js bundle adapter (see `ReactVite.Application`).
+
+  Implements the `Inertia.SSR.Adapter` behaviour. Uses Erlang's built-in
+  `:httpc` client to avoid adding an HTTP dependency to the example.
+
+  ## Options
+
+  - `:vite_url` - base URL of the Vite dev server. Defaults to
+    `"http://127.0.0.1:5173"`. (Use a literal IP rather than `localhost`: the
+    `:httpc` client may resolve `localhost` to IPv6 `::1` while the Vite dev
+    server listens on IPv4 only, causing `:econnrefused`.)
+  - `:ssr_path` - path the SSR endpoint is mounted at. Defaults to
+    `"/__inertia_ssr"`.
+  - `:timeout` - render request timeout in milliseconds. Defaults to `10_000`.
+  """
+
+  @behaviour Inertia.SSR.Adapter
+
+  @impl true
+  def init(opts) do
+    base = Keyword.get(opts, :vite_url, "http://127.0.0.1:5173")
+    path = Keyword.get(opts, :ssr_path, "/__inertia_ssr")
+
+    %{
+      url: String.to_charlist(base <> path),
+      timeout: Keyword.get(opts, :timeout, 10_000)
+    }
+  end
+
+  # The Vite dev server runs as a Phoenix watcher, so there is nothing to
+  # supervise here.
+  @impl true
+  def children(_config), do: []
+
+  @impl true
+  def call(page, %{url: url, timeout: timeout}) when is_map(page) do
+    request = {url, [], ~c"application/json", Jason.encode!(page)}
+
+    case :httpc.request(:post, request, [timeout: timeout], body_format: :binary) do
+      {:ok, {{_, 200, _}, _headers, body}} ->
+        decode_render(body)
+
+      {:ok, {{_, status, _}, _headers, body}} ->
+        {:error, error_message(status, body)}
+
+      {:error, reason} ->
+        {:error, "could not reach Vite SSR dev server at #{url}: #{inspect(reason)}"}
+    end
+  end
+
+  defp decode_render(body) do
+    case Jason.decode(body) do
+      {:ok, %{"head" => head, "body" => body}} -> {:ok, %{"head" => head, "body" => body}}
+      {:ok, other} -> {:error, "unexpected Vite SSR response: #{inspect(other)}"}
+      {:error, error} -> {:error, "invalid JSON from Vite SSR: #{inspect(error)}"}
+    end
+  end
+
+  defp error_message(status, body) do
+    case Jason.decode(body) do
+      {:ok, %{"error" => error}} -> error
+      _ -> "Vite SSR returned HTTP #{status}"
+    end
+  end
+end

--- a/examples/vite/react/mix.exs
+++ b/examples/vite/react/mix.exs
@@ -21,7 +21,8 @@ defmodule ReactVite.MixProject do
   def application do
     [
       mod: {ReactVite.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      # :inets provides the :httpc client used by ReactVite.SSR.ViteAdapter in dev.
+      extra_applications: [:logger, :runtime_tools, :inets]
     ]
   end
 


### PR DESCRIPTION
Render SSR in development through the running Vite dev server via ssrLoadModule, instead of a separate `vite build --ssr --watch`. A dev-only Vite plugin mounts a /__inertia_ssr endpoint, and ReactVite.SSR.ViteAdapter (an Inertia.SSR.Adapter) POSTs page payloads to it. Production continues to use the Node.js bundle adapter.